### PR TITLE
Fix improper rendering for some font sizes

### DIFF
--- a/src/rpc/atom.cpp
+++ b/src/rpc/atom.cpp
@@ -21,6 +21,11 @@ void Atom::draw(const DrawContext &context, const QPoint &position, const Face &
 
     context.painter.setPen(fg);
     context.painter.fillRect(position.x(), position.y(), width, height, bg);
-    context.painter.drawText(QRect(position.x(), position.y(), width, height), Qt::AlignTop, m_contents);
+
+    for (int i = 0; i < m_contents.size(); i++)
+    {
+        context.painter.drawText(QRect(position.x() + i * context.cell_size.width(), position.y(), width, height),
+                                 Qt::AlignTop, m_contents.at(i));
+    }
 }
 } // namespace RPC


### PR DESCRIPTION
This is a hacky way of doing it. I should rather use QTextLayout rather than painter.drawText() in order to support more languages (e.g. the arabic alphabet behaves very differently than the latin alphabet) and to support non-monospace fonts (even though that's kind of cursed)

Closes #3 